### PR TITLE
Use better gitter formatting.

### DIFF
--- a/modules/GitterBridge.js
+++ b/modules/GitterBridge.js
@@ -18,7 +18,7 @@ module.exports = function(Config) {
 		});
 
 		this.freenode.addListener('message' + Config.IRC_Channel, function (from, message) {
-			gitter.say(Config.IRC_Channel, "<" + from + "> " + message);
+			gitter.say(Config.IRC_Channel, "`" + from + "` " + message);
 		});
 
 		this.freenode.addListener('registered', function(message) {


### PR DESCRIPTION
now looks like:

> `nightpool` test 123

instead of:

> <nightpool> test 123
